### PR TITLE
add Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ target
 
 .project
 .classpath
+.settings/
+.factorypath

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: java
+
+sudo: false
+
+jdk:
+  - openjdk8
+
+services:
+  - docker
+
+before_install:
+  - docker pull amazon/dynamodb-local
+  - docker run -d -p 8000:8000 amazon/dynamodb-local
+  - docker ps -a # Display all the dockers
+  - echo "$AWS_ACCESS_KEY_ID"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,15 @@ language: java
 sudo: false
 
 jdk:
-  - openjdk8
+- openjdk8
 
 services:
-  - docker
+- docker
 
 before_install:
-  - docker pull amazon/dynamodb-local
-  - docker run -d -p 8000:8000 amazon/dynamodb-local
-  - docker ps -a # Display all the dockers
-  - echo "$AWS_ACCESS_KEY_ID"
+- export AWS_ACCESS_KEY_ID=ThisIsTheAccessKeyId
+- export AWS_SECRET_ACCESS_KEY=ThisIsRequiredButNotUsed
+- docker pull amazon/dynamodb-local
+- docker run -d -p 8000:8000 amazon/dynamodb-local
+- docker ps -a
+- echo "$AWS_ACCESS_KEY_ID"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 DynamoDB Adapter
 ====
 
+[![Build Status](https://travis-ci.org/jcasbin/dynamodb-adapter.svg?branch=master)](https://travis-ci.org/jcasbin/dynamodb-adapter)
+
 DynamoDB Adapter is the [Amazon DynamoDB](https://en.wikipedia.org/wiki/Amazon_DynamoDB) adapter for [jCasbin](https://github.com/casbin/jcasbin), which provides interfaces for loading policies from DynamoDB and saving policies to it. 
 
 Currently we only support fot the following interfaces:

--- a/src/main/java/org/casbin/adapter/DynamoDBAdapter.java
+++ b/src/main/java/org/casbin/adapter/DynamoDBAdapter.java
@@ -199,8 +199,6 @@ public class DynamoDBAdapter implements Adapter
      */
     @Override
     public void savePolicy(Model model) {
-        this.dropTable();
-        this.createTable();
         for (Map.Entry<String, Assertion> entry : model.model.get("p").entrySet()) {
                 String ptype = entry.getKey();
                 Assertion ast = entry.getValue();

--- a/src/test/java/org/casbin/adapter/DynamoDBAdapterTest.java
+++ b/src/test/java/org/casbin/adapter/DynamoDBAdapterTest.java
@@ -47,6 +47,8 @@ public class DynamoDBAdapterTest
 
         DynamoDBAdapter a = new DynamoDBAdapter(endpoint, region);
 
+        a.createTable();
+
         // Save the current policy to DB
         a.savePolicy(e.getModel());
 
@@ -60,5 +62,6 @@ public class DynamoDBAdapterTest
             asList("bob", "data2", "write"),
             asList("data2_admin", "data2", "read"),
             asList("data2_admin", "data2", "write")));
+        a.dropTable();
     }
 }


### PR DESCRIPTION
In the CI, I use an aws access key. The aws access key is specialized for dynamoDB-adapter CI and is 
currently managed in my personal aws account. 
```
export AWS_ACCESS_KEY_ID=*
export AWS_SECRET_ACCESS_KEY=*
```